### PR TITLE
Replace use of 'which' commands with portable which_works gem.

### DIFF
--- a/schema_dev.gemspec
+++ b/schema_dev.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "its-it"
   spec.add_dependency "key_struct"
   spec.add_dependency "thor"
+  spec.add_dependency "which_works"
 
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/spec/runner_spec.rb
+++ b/spec/runner_spec.rb
@@ -1,4 +1,6 @@
 require 'schema_dev/runner'
+require 'which_works'
+require 'pathname'
 
 describe SchemaDev::Runner do
 
@@ -21,7 +23,7 @@ describe SchemaDev::Runner do
   end
 
   Selectors = {
-    'chruby-exec' => "SHELL=`which bash` chruby-exec ruby-#{RUBY_VERSION} --",
+    'chruby-exec' => "SHELL=#{Which.which 'bash'} chruby-exec ruby-#{RUBY_VERSION} --",
     'rvm' => "rvm #{RUBY_VERSION} do",
     'rbenv' => "RBENV_VERSION=#{RUBY_VERSION}"
   }


### PR DESCRIPTION
Executing a system command "which -s" is not portable; as for example
the GNU which implementation does not support a -s option.

This fix will use the more portable which_works gem, which
re-implements a which command in pure Ruby.