### PR TITLE
Limit pg gem version to < 1 for older Rails versions

### DIFF
--- a/templates/gemfiles/activerecord-3.2/Gemfile.postgresql.erb
+++ b/templates/gemfiles/activerecord-3.2/Gemfile.postgresql.erb
@@ -2,7 +2,7 @@ require "pathname"
 eval(Pathname.new(__FILE__).dirname.join("Gemfile.base").read, binding)
 
 platform :ruby do
-  gem "pg"
+  gem "pg", "< 1"
 end
 
 platform :jruby do

--- a/templates/gemfiles/activerecord-4.0/Gemfile.postgresql.erb
+++ b/templates/gemfiles/activerecord-4.0/Gemfile.postgresql.erb
@@ -2,7 +2,7 @@ require "pathname"
 eval(Pathname.new(__FILE__).dirname.join("Gemfile.base").read, binding)
 
 platform :ruby do
-  gem "pg"
+  gem "pg", "< 1"
 end
 
 platform :jruby do

--- a/templates/gemfiles/activerecord-4.1/Gemfile.postgresql.erb
+++ b/templates/gemfiles/activerecord-4.1/Gemfile.postgresql.erb
@@ -2,7 +2,7 @@ require "pathname"
 eval(Pathname.new(__FILE__).dirname.join("Gemfile.base").read, binding)
 
 platform :ruby do
-  gem "pg"
+  gem "pg", "< 1"
 end
 
 platform :jruby do

--- a/templates/gemfiles/activerecord-4.2.0/Gemfile.postgresql.erb
+++ b/templates/gemfiles/activerecord-4.2.0/Gemfile.postgresql.erb
@@ -2,7 +2,7 @@ require "pathname"
 eval(Pathname.new(__FILE__).dirname.join("Gemfile.base").read, binding)
 
 platform :ruby do
-  gem "pg"
+  gem "pg", "< 1"
 end
 
 platform :jruby do

--- a/templates/gemfiles/activerecord-4.2.1/Gemfile.postgresql.erb
+++ b/templates/gemfiles/activerecord-4.2.1/Gemfile.postgresql.erb
@@ -2,7 +2,7 @@ require "pathname"
 eval(Pathname.new(__FILE__).dirname.join("Gemfile.base").read, binding)
 
 platform :ruby do
-  gem "pg"
+  gem "pg", "< 1"
 end
 
 platform :jruby do

--- a/templates/gemfiles/activerecord-4.2.6/Gemfile.postgresql.erb
+++ b/templates/gemfiles/activerecord-4.2.6/Gemfile.postgresql.erb
@@ -2,7 +2,7 @@ require "pathname"
 eval(Pathname.new(__FILE__).dirname.join("Gemfile.base").read, binding)
 
 platform :ruby do
-  gem "pg"
+  gem "pg", "< 1"
 end
 
 platform :jruby do

--- a/templates/gemfiles/activerecord-4.2/Gemfile.postgresql.erb
+++ b/templates/gemfiles/activerecord-4.2/Gemfile.postgresql.erb
@@ -2,7 +2,7 @@ require "pathname"
 eval(Pathname.new(__FILE__).dirname.join("Gemfile.base").read, binding)
 
 platform :ruby do
-  gem "pg"
+  gem "pg", "< 1"
 end
 
 platform :jruby do

--- a/templates/gemfiles/activerecord-5.0.0/Gemfile.postgresql.erb
+++ b/templates/gemfiles/activerecord-5.0.0/Gemfile.postgresql.erb
@@ -2,7 +2,7 @@ require "pathname"
 eval(Pathname.new(__FILE__).dirname.join("Gemfile.base").read, binding)
 
 platform :ruby do
-  gem "pg"
+  gem "pg", "< 1"
 end
 
 platform :jruby do

--- a/templates/gemfiles/activerecord-5.0.1/Gemfile.postgresql.erb
+++ b/templates/gemfiles/activerecord-5.0.1/Gemfile.postgresql.erb
@@ -2,7 +2,7 @@ require "pathname"
 eval(Pathname.new(__FILE__).dirname.join("Gemfile.base").read, binding)
 
 platform :ruby do
-  gem "pg"
+  gem "pg", "< 1"
 end
 
 platform :jruby do

--- a/templates/gemfiles/activerecord-5.0.2/Gemfile.postgresql.erb
+++ b/templates/gemfiles/activerecord-5.0.2/Gemfile.postgresql.erb
@@ -2,7 +2,7 @@ require "pathname"
 eval(Pathname.new(__FILE__).dirname.join("Gemfile.base").read, binding)
 
 platform :ruby do
-  gem "pg"
+  gem "pg", "< 1"
 end
 
 platform :jruby do

--- a/templates/gemfiles/activerecord-5.0.3/Gemfile.postgresql.erb
+++ b/templates/gemfiles/activerecord-5.0.3/Gemfile.postgresql.erb
@@ -2,7 +2,7 @@ require "pathname"
 eval(Pathname.new(__FILE__).dirname.join("Gemfile.base").read, binding)
 
 platform :ruby do
-  gem "pg"
+  gem "pg", "< 1"
 end
 
 platform :jruby do

--- a/templates/gemfiles/activerecord-5.0/Gemfile.postgresql.erb
+++ b/templates/gemfiles/activerecord-5.0/Gemfile.postgresql.erb
@@ -2,7 +2,7 @@ require "pathname"
 eval(Pathname.new(__FILE__).dirname.join("Gemfile.base").read, binding)
 
 platform :ruby do
-  gem "pg"
+  gem "pg", "< 1"
 end
 
 platform :jruby do

--- a/templates/gemfiles/activerecord-5.1.0/Gemfile.postgresql.erb
+++ b/templates/gemfiles/activerecord-5.1.0/Gemfile.postgresql.erb
@@ -2,7 +2,7 @@ require "pathname"
 eval(Pathname.new(__FILE__).dirname.join("Gemfile.base").read, binding)
 
 platform :ruby do
-  gem "pg"
+  gem "pg", "< 1"
 end
 
 platform :jruby do

--- a/templates/gemfiles/activerecord-5.1.1/Gemfile.postgresql.erb
+++ b/templates/gemfiles/activerecord-5.1.1/Gemfile.postgresql.erb
@@ -2,7 +2,7 @@ require "pathname"
 eval(Pathname.new(__FILE__).dirname.join("Gemfile.base").read, binding)
 
 platform :ruby do
-  gem "pg"
+  gem "pg", "< 1"
 end
 
 platform :jruby do

--- a/templates/gemfiles/activerecord-5.1/Gemfile.postgresql.erb
+++ b/templates/gemfiles/activerecord-5.1/Gemfile.postgresql.erb
@@ -2,7 +2,7 @@ require "pathname"
 eval(Pathname.new(__FILE__).dirname.join("Gemfile.base").read, binding)
 
 platform :ruby do
-  gem "pg"
+  gem "pg", "< 1"
 end
 
 platform :jruby do


### PR DESCRIPTION
Rails has been using `~> 0.x` to specify `pg` gem version ([example here](https://github.com/rails/rails/blob/3acf0de35533a4d26a1299f63deb2be9875d06c0/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb#L16)), and with the release of `pg 1.0.0`, this causes postgresql tests to fail on `schema_dev` as the `pg` gem version cannot be resolved.

rails/rails#31671

`pg 1.0.0` compatibility will be added to Rails in versions `5.1.5` and `5.2`.