### PR TITLE
Fix readme replacement

### DIFF
--- a/lib/schema_dev/readme.rb
+++ b/lib/schema_dev/readme.rb
@@ -58,7 +58,7 @@ module SchemaDev
       replace_block(lines, %r{^\s*<!-- SCHEMA_DEV: TEMPLATE #{key}}) do |contents|
         contents << "<!-- SCHEMA_DEV: TEMPLATE #{key} - begin -->\n"
         contents << "<!-- These lines are auto-inserted from a schema_dev template -->\n"
-        contents << template.readlines
+        contents.concat template.readlines
         contents << "\n"
         contents << "<!-- SCHEMA_DEV: TEMPLATE #{key} - end -->\n"
       end


### PR DESCRIPTION
The readme replacement currently appends the array of new lines instead of the lines themselves. Modifying to concatenating the array instead of appending it fixes there problem.

Found via an error when spinning up a branch on a `schema_plus_triggers`:

```
$ schema_dev bundle install
.../schema_dev-4.2.0/lib/schema_dev/readme.rb:68:in `!~': undefined method `=~' for ["As usual:\n", "\n", "```ruby\n", "gem \"<%= gem_name %>\"                # in a Gemfile\n", "gem.add_dependency \"<%= gem_name %>\" # in a .gemspec\n", "```\n"]:Array (NoMethodError)

  before = lines.take_while { |line| line !~ pattern }
                                          ^^
  from .../schema_dev-4.2.0/lib/schema_dev/readme.rb:68:in `block in replace_block'
  ...
```

### Before

Without this, the first replacement causes `lines` to contain an array instead of only strings:

```
[
  ...,
  "<!-- SCHEMA_DEV: TEMPLATE #{key} - begin -->\n",
  "<!-- These lines are auto-inserted from a schema_dev template -->\n",
  [
    "template line 1\n",
    "template line 2\n",
    ...
  ],
  "\n",
  "<!-- SCHEMA_DEV: TEMPLATE #{key} - end -->\n",
  ...
]
```

### After

`lines` remains an array of strings:

```
[
  ...,
  "<!-- SCHEMA_DEV: TEMPLATE #{key} - begin -->\n",
  "<!-- These lines are auto-inserted from a schema_dev template -->\n",
  "template line 1\n",
  "template line 2\n",
  ...,
  "\n",
  "<!-- SCHEMA_DEV: TEMPLATE #{key} - end -->\n",
  ...
]
```