### PR TITLE
Fix rake create_databases

### DIFF
--- a/lib/schema_dev/tasks/dbms.rb
+++ b/lib/schema_dev/tasks/dbms.rb
@@ -11,14 +11,14 @@ if dbms.any?
       task :create_database do
         require 'active_record'
 
-        config = SchemaDev::Rspec.db_configuration(dbm)
+        config = SchemaDev::Rspec.db_configuration(db: dbm)
 
         ActiveRecord::Tasks::DatabaseTasks.create(config)
       end
       task :drop_databases do
         require 'active_record'
 
-        config = SchemaDev::Rspec.db_configuration(dbm)
+        config = SchemaDev::Rspec.db_configuration(db: dbm)
 
         ActiveRecord::Tasks::DatabaseTasks.drop(config)
       end


### PR DESCRIPTION
It looks like the signature of this method was changed without being updated in these calling sites.

### Before

```sh
$ rake create_databases --trace
** Invoke create_databases (first_time)
** Execute create_databases
** Invoke mysql2:create_database (first_time)
** Execute mysql2:create_database

wrong number of arguments (given 1, expected 0)
** Invoke postgresql:create_database (first_time)
** Execute postgresql:create_database

wrong number of arguments (given 1, expected 0)
rake aborted!
Failure in: mysql2, postgresql
/opt/homebrew/lib/ruby/gems/3.2.0/gems/schema_dev-4.2.0/lib/schema_dev/tasks/dbms.rb:55:in `invoke_multiple'
/opt/homebrew/lib/ruby/gems/3.2.0/gems/schema_dev-4.2.0/lib/schema_dev/tasks/dbms.rb:39:in `block in <top (required)>'
/opt/homebrew/lib/ruby/gems/3.2.0/gems/rake-13.1.0/lib/rake/task.rb:281:in `block in execute'
/opt/homebrew/lib/ruby/gems/3.2.0/gems/rake-13.1.0/lib/rake/task.rb:281:in `each'
/opt/homebrew/lib/ruby/gems/3.2.0/gems/rake-13.1.0/lib/rake/task.rb:281:in `execute'
/opt/homebrew/lib/ruby/gems/3.2.0/gems/rake-13.1.0/lib/rake/task.rb:219:in `block in invoke_with_call_chain'
/opt/homebrew/lib/ruby/gems/3.2.0/gems/rake-13.1.0/lib/rake/task.rb:199:in `synchronize'
/opt/homebrew/lib/ruby/gems/3.2.0/gems/rake-13.1.0/lib/rake/task.rb:199:in `invoke_with_call_chain'
/opt/homebrew/lib/ruby/gems/3.2.0/gems/rake-13.1.0/lib/rake/task.rb:188:in `invoke'
/opt/homebrew/lib/ruby/gems/3.2.0/gems/rake-13.1.0/lib/rake/application.rb:182:in `invoke_task'
/opt/homebrew/lib/ruby/gems/3.2.0/gems/rake-13.1.0/lib/rake/application.rb:138:in `block (2 levels) in top_level'
/opt/homebrew/lib/ruby/gems/3.2.0/gems/rake-13.1.0/lib/rake/application.rb:138:in `each'
/opt/homebrew/lib/ruby/gems/3.2.0/gems/rake-13.1.0/lib/rake/application.rb:138:in `block in top_level'
/opt/homebrew/lib/ruby/gems/3.2.0/gems/rake-13.1.0/lib/rake/application.rb:147:in `run_with_threads'
/opt/homebrew/lib/ruby/gems/3.2.0/gems/rake-13.1.0/lib/rake/application.rb:132:in `top_level'
/opt/homebrew/lib/ruby/gems/3.2.0/gems/rake-13.1.0/lib/rake/application.rb:83:in `block in run'
/opt/homebrew/lib/ruby/gems/3.2.0/gems/rake-13.1.0/lib/rake/application.rb:208:in `standard_exception_handling'
/opt/homebrew/lib/ruby/gems/3.2.0/gems/rake-13.1.0/lib/rake/application.rb:80:in `run'
/opt/homebrew/lib/ruby/gems/3.2.0/gems/rake-13.1.0/exe/rake:27:in `<top (required)>'
/Users/sj26/.rbenv/versions/3.2.2/bin/rake:25:in `load'
/Users/sj26/.rbenv/versions/3.2.2/bin/rake:25:in `<main>'
Tasks: TOP => create_databases
```

### After

```sh
$ rake create_databases --trace
** Invoke create_databases (first_time)
** Execute create_databases
** Invoke mysql2:create_database (first_time)
** Execute mysql2:create_database
Created database 'schema_plus_test'
** Invoke postgresql:create_database (first_time)
** Execute postgresql:create_database
Created database 'schema_plus_test'
```